### PR TITLE
fix(download): treat a short clean EOF as resumable, not complete

### DIFF
--- a/go_backend/extension_runtime_file.go
+++ b/go_backend/extension_runtime_file.go
@@ -356,7 +356,16 @@ func (r *extensionRuntime) fileDownload(call goja.FunctionCall) goja.Value {
 			return fatal
 		}
 		if readErr == nil {
-			break
+			if contentLength <= 0 || written == contentLength {
+				break
+			}
+			// The body reported a clean EOF (e.g. a mid-transfer connection
+			// reset that the transport surfaced as normal end-of-stream
+			// instead of io.ErrUnexpectedEOF) but fewer bytes arrived than
+			// the server promised in Content-Length. Route it through the
+			// same resume-or-fail path as a real read error instead of
+			// silently promoting a truncated file.
+			readErr = io.ErrUnexpectedEOF
 		}
 
 		stalled := wd.stalled.Load()

--- a/go_backend/extension_runtime_file_download_integrity_test.go
+++ b/go_backend/extension_runtime_file_download_integrity_test.go
@@ -1,0 +1,149 @@
+package gobackend
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+// shortCleanEOFBodyReader simulates a transport that surfaces a mid-transfer
+// connection drop as a normal io.EOF instead of io.ErrUnexpectedEOF (which is
+// what a network reset looks like through some custom transports, e.g. the
+// uTLS-based client this app uses for TLS-fingerprint spoofing). It sends
+// data once and then reports a clean end of stream, even though fewer bytes
+// were sent than the response's Content-Length promised.
+type shortCleanEOFBodyReader struct {
+	data []byte
+	sent bool
+}
+
+func (f *shortCleanEOFBodyReader) Read(p []byte) (int, error) {
+	if !f.sent {
+		f.sent = true
+		n := copy(p, f.data)
+		return n, io.EOF
+	}
+	return 0, io.EOF
+}
+
+func TestFileDownloadShortCleanEOFFailsByDefaultEvenWithValidator(t *testing.T) {
+	var attempts int
+	runtime := newFileDownloadTestRuntime(t, func(req *http.Request) (*http.Response, error) {
+		attempts++
+		h := make(http.Header)
+		h.Set("ETag", `"v1"`)
+		return &http.Response{
+			StatusCode:    200,
+			Header:        h,
+			Body:          io.NopCloser(&shortCleanEOFBodyReader{data: []byte("hello-")}),
+			ContentLength: int64(len("hello-world!")),
+			Request:       req,
+		}, nil
+	})
+
+	// Resume is opt-in (see fileDownload's canResume comment), so a short
+	// clean EOF must fail and clean up just like a real read error would,
+	// not silently resume just because a validator happens to be present.
+	result := runtime.fileDownload(goja.FunctionCall{Arguments: []goja.Value{
+		runtime.vm.ToValue("https://cdn.example.com/track.flac"),
+		runtime.vm.ToValue("out/track.flac"),
+	}}).Export().(map[string]any)
+	if result["success"] != false {
+		t.Fatalf("expected failed download, got %#v", result)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want no automatic resume", attempts)
+	}
+
+	finalPath := filepath.Join(runtime.dataDir, "out", "track.flac")
+	if _, err := os.Stat(finalPath); !os.IsNotExist(err) {
+		t.Fatalf("truncated download was promoted to the final path: %v", err)
+	}
+	if _, err := os.Stat(stagedDownloadPath(finalPath)); !os.IsNotExist(err) {
+		t.Fatalf("staged partial file left behind: %v", err)
+	}
+}
+
+func TestFileDownloadResumesAfterShortCleanEOFWhenEnabled(t *testing.T) {
+	const full = "hello-world!"
+	var attempts int
+	var resumeRange, resumeIfRange string
+	runtime := newFileDownloadTestRuntime(t, func(req *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			h := make(http.Header)
+			h.Set("ETag", `"v1"`)
+			return &http.Response{
+				StatusCode:    200,
+				Header:        h,
+				Body:          io.NopCloser(&shortCleanEOFBodyReader{data: []byte(full[:6])}),
+				ContentLength: int64(len(full)),
+				Request:       req,
+			}, nil
+		}
+		resumeRange = req.Header.Get("Range")
+		resumeIfRange = req.Header.Get("If-Range")
+		h := make(http.Header)
+		h.Set("Content-Range", fmt.Sprintf("bytes 6-%d/%d", len(full)-1, len(full)))
+		return &http.Response{
+			StatusCode:    206,
+			Header:        h,
+			Body:          io.NopCloser(&shortCleanEOFBodyReader{data: []byte(full[6:])}),
+			ContentLength: int64(len(full) - 6),
+			Request:       req,
+		}, nil
+	})
+
+	result := runtime.fileDownload(goja.FunctionCall{Arguments: []goja.Value{
+		runtime.vm.ToValue("https://cdn.example.com/track.flac"),
+		runtime.vm.ToValue("out/track.flac"),
+		runtime.vm.ToValue(map[string]any{"resume": true}),
+	}}).Export().(map[string]any)
+	if result["success"] != true {
+		t.Fatalf("download result = %#v", result)
+	}
+	if attempts != 2 || resumeRange != "bytes=6-" || resumeIfRange != `"v1"` {
+		t.Fatalf("attempts=%d range=%q if-range=%q", attempts, resumeRange, resumeIfRange)
+	}
+
+	finalPath := filepath.Join(runtime.dataDir, "out", "track.flac")
+	data, err := os.ReadFile(finalPath)
+	if err != nil || string(data) != full {
+		t.Fatalf("final file = %q/%v (a truncated file was silently promoted)", data, err)
+	}
+}
+
+func TestFileDownloadShortCleanEOFWithoutValidatorFails(t *testing.T) {
+	runtime := newFileDownloadTestRuntime(t, func(req *http.Request) (*http.Response, error) {
+		// No ETag/Last-Modified, so the download cannot be resumed and must
+		// fail outright rather than promote a truncated file.
+		return &http.Response{
+			StatusCode:    200,
+			Header:        make(http.Header),
+			Body:          io.NopCloser(&shortCleanEOFBodyReader{data: []byte("partial-aud")}),
+			ContentLength: 1 << 20,
+			Request:       req,
+		}, nil
+	})
+
+	result := runtime.fileDownload(goja.FunctionCall{Arguments: []goja.Value{
+		runtime.vm.ToValue("https://cdn.example.com/track.flac"),
+		runtime.vm.ToValue("out/track.flac"),
+	}}).Export().(map[string]any)
+	if result["success"] != false {
+		t.Fatalf("expected a failed download for a short clean EOF with no validator, got %#v", result)
+	}
+
+	finalPath := filepath.Join(runtime.dataDir, "out", "track.flac")
+	if _, err := os.Stat(finalPath); !os.IsNotExist(err) {
+		t.Fatalf("truncated download was promoted to the final path: %v", err)
+	}
+	if _, err := os.Stat(stagedDownloadPath(finalPath)); !os.IsNotExist(err) {
+		t.Fatalf("staged partial file left behind: %v", err)
+	}
+}


### PR DESCRIPTION
Follow-up to #491, which was fixed in 4.8.5 by making mid-download resume opt-in (safe default: fail and delete the staged partial file, since switching networks can route a stable URL to a different CDN object even with an unchanged validator).

### The remaining gap

That fix only changes behavior for a *real* read error. `fileDownload`'s `copyBody` loop still breaks out and promotes the file on **any** clean `io.EOF`, without checking whether the bytes written actually reached the response's `Content-Length`. Some transports (this app's uTLS-based client, used for TLS-fingerprint spoofing, is exactly this kind of custom transport) can surface a mid-transfer connection drop as a plain `io.EOF` instead of `io.ErrUnexpectedEOF` — so a network change mid-download could still get silently promoted as a "successful" truncated file, bypassing the new opt-in resume logic entirely (it never even reaches the `canResume` check).

### The fix

A clean EOF short of a known `Content-Length` is now routed through the same resume-or-fail path as a real read error, so it respects the same `resume` option introduced in 4.8.5:
- Fails and cleans up the staged file by default (matching the safe-default policy).
- Resumes via `Range`/`If-Range` when the caller passed `resume: true` and the server provided a validator.

### Tests

`extension_runtime_file_download_integrity_test.go` adds three tests, verified to fail on the pre-fix code and pass with it:
- `TestFileDownloadShortCleanEOFFailsByDefaultEvenWithValidator` — fails and cleans up by default, even with a validator present.
- `TestFileDownloadResumesAfterShortCleanEOFWhenEnabled` — resumes and completes correctly with `resume: true`.
- `TestFileDownloadShortCleanEOFWithoutValidatorFails` — fails and leaves no file behind when there's no validator at all.

### Known follow-up (not in this PR)

`fileDownloadChunked`'s unknown-total-size path (used for YouTube's CDN, where the total length isn't known upfront) has an analogous but harder-to-fix ambiguity: without a known length, there's no reliable way to distinguish a legitimately short final chunk from a truncated one.

### Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- `go test ./...` — all green, including the 3 new tests
- Rebased onto current `main` after the 4.8.5 resume changes landed
